### PR TITLE
fix helm-gtags-select error

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -435,12 +435,14 @@
         (buf (get-buffer-create helm-gtags-buffer))
         (dir (helm-gtags-searched-directory))
         (src (car srcs)))
+    (when (symbolp src)
+      (setq src (symbol-value src)))
     (when (helm-gtags--using-other-window-p)
       (setq helm-gtags-use-otherwin t))
-    (helm-attrset 'helm-gtags-base-directory dir (symbol-value src))
+    (helm-attrset 'helm-gtags-base-directory dir src)
     (helm-attrset 'name
                   (format "Searched at %s" (or dir default-directory))
-                  (symbol-value src))
+                  src)
     (helm :sources srcs :buffer buf)))
 
 ;;;###autoload


### PR DESCRIPTION
It is an error to the `helm-gtags-select` and `Goto the location` action.
`helm-source-gtags-select-tag-action` is called the `helm-gtags-common` but it is wrong type argument.

``` cl
Debugger entered--Lisp error: (wrong-type-argument symbolp ((name . "GNU GLOBAL") (init lambda nil (helm-gtags-tags-init "Actor")) (candidates-in-buffer) (candidate-number-limit . 9999) (action . helm-gtags-action-openfile)))
  symbol-value(((name . "GNU GLOBAL") (init lambda nil (helm-gtags-tags-init "Actor")) (candidates-in-buffer) (candidate-number-limit . 9999) (action . helm-gtags-action-openfile)))
  (helm-attrset (quote helm-gtags-base-directory) dir (symbol-value src))
  (let ((helm-quit-if-no-candidate t) (helm-execute-action-at-once-if-one t) (buf (get-buffer-create helm-gtags-buffer)) (dir (helm-gtags-searched-directory)) (src (car srcs))) (if (helm-gtags--using-other-window-p) (progn (setq helm-gtags-use-otherwin t))) (helm-attrset (quote helm-gtags-base-directory) dir (symbol-value src)) (helm-attrset (quote name) (format "Searched at %s" (or dir default-directory)) (symbol-value src)) (helm :sources srcs :buffer buf))
  helm-gtags-common((((name . "GNU GLOBAL") (init lambda nil (helm-gtags-tags-init "Actor")) (candidates-in-buffer) (candidate-number-limit . 9999) (action . helm-gtags-action-openfile))))
  (lambda nil (helm-gtags-common (list (helm-source-gtags-select-tag "Actor"))))()
  apply((lambda nil (helm-gtags-common (list (helm-source-gtags-select-tag "Actor")))) nil)
  byte-code("r\301\302H\303H\"\210)\301\207" [timer apply 5 6] 4)
  timer-event-handler([t 20965 26258 881748 nil (lambda nil (helm-gtags-common (list (helm-source-gtags-select-tag "Actor")))) nil nil 0])

```
