### PR TITLE
Recenter after jumping to line.

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -432,6 +432,7 @@ Always update if value of this variable is nil."
   (funcall open-func file helm-gtags-read-only)
   (goto-char (point-min))
   (forward-line (1- line))
+  (recenter)
   (helm-gtags--push-context helm-gtags-saved-context))
 
 (defun helm-gtags-parse-file-action (cand)


### PR DESCRIPTION
Emacs doesn't recenter automatically if smooth scrolling is configured.
