### PR TITLE
Support `helm-gtags-find-tag-from-here` over TRAMP

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -460,7 +460,9 @@ Always update if value of this variable is nil."
   (helm-gtags-find-tag-directory)
   (helm-gtags-save-current-context)
   (let* ((token (helm-gtags-token-at-point))
-         (filename (buffer-file-name))
+         (filename (if helm-gtags--remote-p
+                       (tramp-file-name-localname (tramp-dissect-file-name (buffer-file-name)))
+                       (buffer-file-name)))
          (cmd (format "global --result=grep --from-here=%d:%s %s"
                       (line-number-at-pos)
                       (shell-quote-argument filename)


### PR DESCRIPTION
`helm-gtags-find-tag-from-here` function invokes `global` with TRAMP filename, such as `global --result grep --from-here 100:/ssh:foo:/home/nksm/bar.c foo`

This commit fixes `helm-gtags-find-tag-from-here` to invoke `global` with remote filename.
