### PR TITLE
implement helm-gtags-suggested-key-mappings

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -117,6 +117,17 @@ Always update if value of this variable is nil."
   :type 'boolean
   :group 'helm-gtags)
 
+(defcustom helm-gtags-prefix-key "\C-c"
+  "*If non-nil, it is used for the prefix key of gtags-xxx command."
+  :group 'gtags
+  :type 'string)
+
+(defcustom helm-gtags-suggested-key-mapping nil
+  "*If non-nil, suggested key mapping is enabled."
+  :group 'gtags
+  :type 'boolean)
+
+
 (defface helm-gtags-file
   '((t :inherit font-lock-keyword-face))
   "Face for line numbers in the error list."
@@ -951,6 +962,23 @@ Generate new TAG file in selected directory with `C-u C-u'"
     (progn
       (when helm-gtags-auto-update
         (remove-hook 'after-save-hook 'helm-gtags-update-tags t)))))
+
+;; Key mapping of gtags-mode.
+(if helm-gtags-suggested-key-mapping
+    (progn
+      ; Current key mapping.
+      (define-key helm-gtags-mode-map "\C-]" 'helm-gtags-find-tag-from-here)
+      (define-key helm-gtags-mode-map "\C-t" 'helm-gtags-pop-stack)
+      (define-key helm-gtags-mode-map (concat helm-gtags-prefix-key "P") 'helm-gtags-find-files)
+      (define-key helm-gtags-mode-map (concat helm-gtags-prefix-key "f") 'helm-gtags-parse-file)
+      (define-key helm-gtags-mode-map (concat helm-gtags-prefix-key "s") 'helm-gtags-find-symbol)
+      (define-key helm-gtags-mode-map (concat helm-gtags-prefix-key "r") 'helm-gtags-find-rtag)
+      (define-key helm-gtags-mode-map (concat helm-gtags-prefix-key "t") 'helm-gtags-find-tag)
+      (define-key helm-gtags-mode-map (concat helm-gtags-prefix-key "d") 'helm-gtags-find-tag)
+
+      ; common
+      (define-key helm-gtags-mode-map "\e*" 'helm-gtags-pop-stack)
+      (define-key helm-gtags-mode-map "\e." 'helm-gtags-find-tag)))
 
 (provide 'helm-gtags)
 


### PR DESCRIPTION
gtags.el has gtags-suggested-key-mapping custom variable and I love it.
So, this patch aims similar feature.

helm-gtags-suggested-key-mapping have a very few unimplemented command.
- C-c h: 'gtags-display-browser
- C-c g: 'gtags-find-with-grep
- C-c v: 'gtags-find-with-idutils
- C-c v: 'gtags-visit-rootdir
- "\C-x4.": 'gtags-find-tag-other-window

because I didn't find similar feature in helm-gtags.el.

Signed-off-by: KOSAKI Motohiro kosaki.motohiro@gmail.com
