### PR TITLE
Make real-file-name resolve symlinks correctly

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -509,7 +509,7 @@ Always update if value of this variable is nil."
       (error "This buffer is not related to file."))
     (if (file-remote-p buffile)
         (tramp-file-name-localname (tramp-dissect-file-name buffile))
-      buffile)))
+      (file-truename buffile))))
 
 (defun helm-gtags--find-tag-from-here-init ()
   (helm-gtags--find-tag-directory)


### PR DESCRIPTION
I went through a lot of trouble to debug this issue: when the source tree directory is a symlink to the actual source tree, nothing works. Use file-truename to fix this.