### PR TITLE
This commit fixes a problem when calculating the position of beginning o...

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -501,6 +501,48 @@ Always update if value of this variable is nil."
     (setq helm-gtags--last-input input)
     (reverse (cons input options))))
 
+(defun helm-gtgs--exec-global-command-local (type input)
+  (with-temp-buffer
+    (let ((args (reverse (cons input (helm-gtags--construct-options type nil)))))
+      (progn
+        (push "-a" args)
+        (apply 'process-file "global" nil '(t nil) nil args)
+        (buffer-substring-no-properties (point-min) (point-max))))))
+
+(defun helm-gtags--which-function-only-func-name ()
+  (if (string-match "lisp-mode$" (symbol-name major-mode))
+      (which-function)
+    (save-excursion
+      (progn
+        (beginning-of-defun)
+        (when (re-search-forward "(" nil t)
+          (forward-char -1)
+          (let ((end (point)))
+            (skip-chars-backward "_A-Za-z0-9")
+            (buffer-substring-no-properties (point) end)))))))
+
+(defun helm-gtags--tag-included-in-bound (bound tag-line)
+  (ignore-errors
+    (let* ((tag-elms (split-string tag-line ":"))
+           (tag-file-name (car tag-elms))
+           (line-num (string-to-int (car (cdr tag-elms)))))
+      (when (and (string= tag-file-name (buffer-file-name))
+               (and (<= line-num (cdr bound))
+               (>= line-num (car bound))))
+          line-num))))
+
+(defun helm-gtags--current-function-beginning-line ()
+  (let* ((bound (helm-gtags--current-funcion-bound))
+         (func (helm-gtags--which-function-only-func-name))
+         (found-tags (helm-gtgs--exec-global-command-local 'tag func))
+         (matched-tag
+          (delete nil
+                  (cl-loop for tag-line in (split-string found-tags "\n")
+                           collect
+                           (helm-gtags--tag-included-in-bound
+                            bound tag-line)))))
+    (or (car matched-tag) 0)))
+
 (defun helm-gtags--tags-init (&optional input)
   (helm-gtags--exec-global-command 'tag input))
 
@@ -1079,7 +1121,7 @@ You can jump definitions of functions, symbols in this file."
                 helm-source-gtags-parse-file)
   (let ((presel (when helm-gtags-preselect
                   (format "^\\S-+\\s-+%d\\s-+"
-                          (line-number-at-pos)))))
+                          (helm-gtags--current-function-beginning-line)))))
     (helm :sources '(helm-source-gtags-parse-file)
           :buffer helm-gtags--buffer :preselect presel)))
 


### PR DESCRIPTION
Hello again!

I have realized a problem in the previous patch!

Previously, it uses line-number-at-pos to get line number of defun. This works only when the cursor is on the same line as defun. However, I think we want to execute helm-gtags-parse-file at any place within a source code. It's more useful if preselect is available when the cursor is not on the same line as defun.

To achieve this, I tried to use helm-gtags--current-function-bound, but I faced another problem. The helm-gtags--current-function-bound uses beginning-of-defun to find the position of defun, however, return value of beginning-of-defun is not necessarily same as the value retrieved from global command. For example, line numbers will mismatch between beginning-of-defun and global. See the following example.

1: void
2: main()
3: {
4:   puts("Hello world!");
5: }

In this case, beginning-of-defun moves to line 1 while global returns line 2 on the other hand. Due to this mismatch, simple regex based comparison doesn't work in such case and results in inability to construct correct preselect. The simplest way to solve this problem is to use global to construct preselect regex pattern. In this patch, I introduced several functions to do it.

Kind regards!