### PR TITLE
Added missing period to defgroup DOC string.

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -59,7 +59,7 @@
 (declare-function cygwin-convert-file-name-to-windows "cygw32.c")
 
 (defgroup helm-gtags nil
-  "GNU GLOBAL for helm"
+  "GNU GLOBAL for helm."
   :group 'helm)
 
 (defcustom helm-gtags-path-style 'root


### PR DESCRIPTION
"Third argument DOC is the group documentation. This should be a short description of the group, beginning with a capital and ending with a period."