### PR TITLE
Remove '^M' at end of line on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,16 @@
-language: emacs-lisp
-env:
-  matrix:
-    - EMACS=emacs24
-    - EMACS=emacs-snapshot
-  global:
-    - CASK=$HOME/.cask/bin/cask
+language: generic
+sudo: false
 before_install:
-  - sudo add-apt-repository -y ppa:cassou/emacs
-  - sudo add-apt-repository -y ppa:ubuntu-elisp/ppa
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq $EMACS
-  - if [ "$EMACS" = 'emacs-snapshot' ]; then
-      sudo apt-get install -qq emacs-snapshot-el emacs-snapshot-nox;
-    fi
-  - sudo apt-get install -qq global
-  - curl -fsSkL --max-time 10 --retry 10 --retry-delay 10
-        https://raw.github.com/cask/cask/master/go | python
+  - curl -L http://tamacom.com/global/global-6.5.1.tar.gz | tar xzf -
+  - (cd global-6.5.1 && ./configure --prefix=/home/travis/global && make && make install)
+  - export PATH=/home/travis/global/bin:$PATH
+  - curl -fsSkL https://gist.github.com/rejeep/ebcd57c3af83b049833b/raw > x.sh && source ./x.sh
+  - evm install $EVM_EMACS --use --skip
+  - cask
+env:
+  - EVM_EMACS=emacs-24.3-travis
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-24.5-travis
 script:
-  make test
+  - emacs --version
+  - make test


### PR DESCRIPTION
'^M' causes error when jumping to files.

This is related to #136.