### PR TITLE
make the argument for helm-gtags--select-cache-init-common a list

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -932,7 +932,7 @@ Always update if value of this variable is nil."
           (progn
             (process-file "global" nil t nil options)
             (helm-gtags--remove-carrige-returns))
-        (helm-gtags--select-cache-init-common options "GPATH")))))
+        (helm-gtags--select-cache-init-common (list options) "GPATH")))))
 
 (defvar helm-source-gtags-select-path
   (helm-build-in-buffer-source "Select path"


### PR DESCRIPTION
Pass a list to helm-gtags--select-cache-init-common, otherwise helm-gtags-select-path complains a wrong type argument error.