### PR TITLE
Fix for invalid modifier string like "C-,"

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,17 @@ buffer if other helm commands are called.
 `helm-gtags-suggested-key-mapping` to non-nil. Its prefix key is `C-c`
 as default. You can change prefix by setting `helm-gtags-prefix-key`.
 
-These value must be set before loading `helm-gtags.el`.
+You have to set them before loading `helm-gtags.el`.
 I recommend you to use `custom-set-variables` for setting this value.
 
 ```lisp
 (custom-set-variables
- '(helm-gtags-prefix-key "C-t")
+ '(helm-gtags-prefix-key "\C-t")
  '(helm-gtags-suggested-key-mapping t))
 ```
+
+If you use `invalid modifier string`(like `C-,`) as prefix key, please don't
+escape Control prefix.(OK: `C-,`, NG: `\C-,`).
 
 ### Default Key Mapping
 

--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -1263,19 +1263,24 @@ Generate new TAG file in selected directory with `C-u C-u'"
 ;; Key mapping of gtags-mode.
 (when helm-gtags-suggested-key-mapping
   ;; Current key mapping.
-  (let ((prefix helm-gtags-prefix-key))
-    (define-key helm-gtags-mode-map (concat prefix "h") 'helm-gtags-display-browser)
-    (define-key helm-gtags-mode-map "\C-]" 'helm-gtags-find-tag-from-here)
-    (define-key helm-gtags-mode-map "\C-t" 'helm-gtags-pop-stack)
-    (define-key helm-gtags-mode-map (concat prefix "P") 'helm-gtags-find-files)
-    (define-key helm-gtags-mode-map (concat prefix "f") 'helm-gtags-parse-file)
-    (define-key helm-gtags-mode-map (concat prefix "g") 'helm-gtags-find-pattern)
-    (define-key helm-gtags-mode-map (concat prefix "s") 'helm-gtags-find-symbol)
-    (define-key helm-gtags-mode-map (concat prefix "r") 'helm-gtags-find-rtag)
-    (define-key helm-gtags-mode-map (concat prefix "t") 'helm-gtags-find-tag)
-    (define-key helm-gtags-mode-map (concat prefix "d") 'helm-gtags-find-tag)
+  (let ((command-table '(("h" . helm-gtags-display-browser)
+                         ("P" . helm-gtags-find-files)
+                         ("f" . helm-gtags-parse-file)
+                         ("g" . helm-gtags-find-pattern)
+                         ("s" . helm-gtags-find-symbol)
+                         ("r" . helm-gtags-find-rtag)
+                         ("t" . helm-gtags-find-tag)
+                         ("d" . helm-gtags-find-tag)))
+        (key-func (if (string-prefix-p "\\" helm-gtags-prefix-key)
+                      #'concat
+                    (lambda (prefix key) (kbd (concat prefix " " key))))))
+    (cl-loop for (key . command) in command-table
+             do
+             (define-key helm-gtags-mode-map (funcall key-func helm-gtags-prefix-key key) command))
 
     ;; common
+    (define-key helm-gtags-mode-map "\C-]" 'helm-gtags-find-tag-from-here)
+    (define-key helm-gtags-mode-map "\C-t" 'helm-gtags-pop-stack)
     (define-key helm-gtags-mode-map "\e*" 'helm-gtags-pop-stack)
     (define-key helm-gtags-mode-map "\e." 'helm-gtags-find-tag)
     (define-key helm-gtags-mode-map "\C-x4." 'helm-gtags-find-tag-other-window)))


### PR DESCRIPTION
This is related to #149.
CC: @introom

This change is for invalid modifier string like `C-,`. You can got error by evaluating such string.

```lisp
"\C-,"
=> elisp--preceding-sexp: Invalid modifier in string
```

You can use such string by adding following configuration. You need not to escape control or meta prefix.(OK: `C-,`, NG: `\C-,`)

```lisp
(custom-set-variables
 '(helm-gtags-prefix-key "C-,"))
```