### PR TITLE
add new-ctags to label candidates

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -974,7 +974,7 @@ Always update if value of this variable is nil."
         (message "Failed: %s TAGS(%d)" action (process-exit-status process))))))
 
 (defsubst helm-gtags--read-gtagslabel ()
-  (let ((labels '("default" "native" "ctags" "pygments")))
+  (let ((labels '("default" "native" "ctags" "new-ctags" "pygments")))
     (completing-read "GTAGSLABEL(Default: default): " labels nil t nil nil "default")))
 
 (defsubst helm-gtags--label-option (label)


### PR DESCRIPTION
universal-ctags can be used with the label new-ctags. Documentation is sparse, but the default gtags.conf is helpful. There is also a configure option --with-universal-ctags comparable to --with-exuberant-ctags.