### PR TITLE
Format for helm-gtags-parse-file output.

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,11 +279,19 @@ and GNU global, please set `nil` to this variable.
 
 #### `helm-gtags-file`
 
-Face of file name of candidates
+Face used for file name.
 
 #### `helm-gtags-lineno`
 
-Face of line number of candidates
+Face used for line number.
+
+#### `helm-gtags-match`
+
+Face used for tag highlight.
+
+#### `helm-gtags-tag`
+
+Face used for tag.
 
 
 ## anything-gtags.el

--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -142,15 +142,19 @@ Always update if value of this variable is nil."
 
 (defface helm-gtags-file
   '((t :inherit font-lock-keyword-face))
-  "Face for line numbers in the error list.")
+  "Face used for file name.")
 
 (defface helm-gtags-lineno
   '((t :inherit font-lock-doc-face))
-  "Face for line numbers in the error list.")
+  "Face used for line number.")
 
 (defface helm-gtags-match
   '((t :inherit helm-match))
-  "Face for word matched against tagname")
+  "Face used to highlight a tag matched in a selected line.")
+
+(defface helm-gtags-tag
+  '((t :inherit font-lock-string-face))
+  "Face used for tag.")
 
 (defvar helm-gtags--tag-location nil)
 (defvar helm-gtags--last-update-time 0)
@@ -745,10 +749,11 @@ Always update if value of this variable is nil."
 (defun helm-gtags--parse-file-candidate-transformer (file)
   (let ((removed-file (replace-regexp-in-string "\\`\\S-+ " "" file)))
     (when (string-match "\\`\\(\\S-+\\) \\(\\S-+\\) \\(.+\\)\\'" removed-file)
-      (format "%-25s %-5s %s"
-              (match-string-no-properties 1 removed-file)
-              (match-string-no-properties 2 removed-file)
-              (match-string-no-properties 3 removed-file)))))
+      (setq helm-gtags--last-input (match-string 1 removed-file))
+      (format "%s:%s:%s"
+              (propertize (match-string 1 removed-file) 'face 'helm-gtags-tag)
+              (propertize (match-string 2 removed-file) 'face 'helm-gtags-lineno)
+              (helm-gtags--highlight-candidate (match-string 3 removed-file))))))
 
 (defvar helm-source-gtags-find-tag-from-here
   (helm-build-in-buffer-source "Find tag from here"


### PR DESCRIPTION
Syohei-san.

I think current helm-output of helm-gtags-parse-file is unreadable:
![before](https://cloud.githubusercontent.com/assets/1120058/24060917/a8c2aba4-0b55-11e7-93b5-7a8c8641527d.png)

I'm proposing another output format:
![after](https://cloud.githubusercontent.com/assets/1120058/24060955/cee1c6a8-0b55-11e7-9d39-0a279a73f9bf.png)
![after2](https://cloud.githubusercontent.com/assets/1120058/24060962/d329a514-0b55-11e7-91df-855233d78a41.png)

Regards.