### PR TITLE
Fix byte-compilation warnings

### DIFF
--- a/helm-gtags.el
+++ b/helm-gtags.el
@@ -107,8 +107,8 @@
   :group 'helm-gtags)
 
 (defcustom helm-gtags-update-interval-second 60
-  "Tags are updated in `after-save-hook' if this seconds is passed from \
-last update.
+  "Update interval in seconds for tags in `after-save-hook'.
+Tags are updated if this many seconds have passed since last update.
 Always update if value of this variable is nil."
   :type '(choice (integer :tag "Update interval seconds")
                  (boolean :tag "Update every time" nil))
@@ -1199,7 +1199,8 @@ Always update if value of this variable is nil."
           (progn
             (fit-window-to-buffer win)
             (when (yes-or-no-p "Remove GNU Global tag files? ")
-              (with-demoted-errors (mapc #'delete-file files))))
+              (with-demoted-errors "Error deleting files: %S"
+                (mapc #'delete-file files))))
         (when (window-live-p win)
           (quit-window t win))))))
 


### PR DESCRIPTION
Address two byte-compilation warnings found during testing on Fedora Rawhide with Emacs 30.2:

1. with-demoted-errors: Add required format string
   helm-gtags.el:1197: Missing format argument in 'with-demoted-errors'

   Fix: Add "Error deleting files: %S" format string.
   Required by with-demoted-errors since Emacs 24.4.

2. Docstring line length: Reformat to fit 80-character limit
   helm-gtags.el:117: custom-declare-variable docstring too wide

   Fix: Break into multiple lines and improve grammar.
   "this seconds is passed" → "this many seconds have passed"

These are purely stylistic fixes with no functional changes. Tested with byte-compilation on Emacs 27.2-30.2.